### PR TITLE
Add MLX LoRA fine-tuning template

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install linters
+        run: |
+          python -m pip install --upgrade pip
+          pip install black ruff
+      - name: Run linters
+        run: |
+          black --check .
+          ruff .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# cbnu-acr-mlx-
+# CBNU Academic Rules LoRA fine-tuning (MLX)
+
+Fine-tune beomi/Llama-3-Open-Ko-8B with LoRA on the Chungbuk National University academic rules Q&A dataset using Apple's MLX framework.
+
+## Setup (macOS zsh)
+
+```zsh
+# create and activate virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# install dependencies
+pip install -r requirements.txt
+
+# authenticate with Hugging Face
+export HUGGING_FACE_HUB_TOKEN=your_hf_token
+```
+
+> **Security**: store the token in environment variables or keychain, not in source files.
+
+## Training
+
+The script automatically creates `data/chungbuk_univ_academic_rules_QA.csv` with three dummy rows if it is missing.
+
+```zsh
+# optional: override base model
+export BASE_MODEL=beomi/Llama-3-Open-Ko-8B
+
+python train_acr.py \
+  --max_seq_length 512 \
+  --lora_r 16 --lora_alpha 32 --lora_dropout 0.05 \
+  --num_epochs 3 --batch_size 1 --learning_rate 2e-4
+```
+
+If memory is insufficient, try `--max_seq_length 384` or `256`, and `--lora_r 8`.
+
+## Inference
+
+```zsh
+# after training, run interactive chat applying the adapter
+python infer.py
+```
+
+Environment variables:
+- `BASE_MODEL` – default `beomi/Llama-3-Open-Ko-8B`
+- `ADAPTER_PATH` – LoRA adapter file (default `adapters.safetensors`)
+
+Both scripts use the fixed system prompt:
+> "너는 충북대학교 학칙 Q&A 어시스턴트다. 학칙에 근거해 정확·간결하게 한국어로 답한다."
+
+## Lint
+
+To check formatting locally:
+
+```zsh
+pip install black ruff
+black .
+ruff .
+```

--- a/infer.py
+++ b/infer.py
@@ -1,0 +1,31 @@
+import os
+
+from mlx_lm import generate, load
+
+SYSTEM_PROMPT = "너는 충북대학교 학칙 Q&A 어시스턴트다. 학칙에 근거해 정확·간결하게 한국어로 답한다."
+
+
+def main() -> None:
+    base_model = os.getenv("BASE_MODEL", "beomi/Llama-3-Open-Ko-8B")
+    adapter_path = os.getenv("ADAPTER_PATH", "adapters.safetensors")
+    model, tokenizer = load(base_model, adapter_path=adapter_path)
+
+    print("Ctrl-D to exit.")
+    while True:
+        try:
+            question = input("User: ")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not question.strip():
+            continue
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ]
+        prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+        answer = generate(model, tokenizer, prompt, max_tokens=256)
+        print("Assistant:", answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mlx
+mlx-lm
+datasets
+huggingface_hub

--- a/train_acr.py
+++ b/train_acr.py
@@ -1,0 +1,126 @@
+import argparse
+import csv
+import json
+import os
+from pathlib import Path
+from typing import List
+
+import mlx.optimizers as opt
+from mlx_lm import generate, load
+from mlx_lm.tuner import TrainingArgs, linear_to_lora_layers, train
+
+SYSTEM_PROMPT = "너는 충북대학교 학칙 Q&A 어시스턴트다. 학칙에 근거해 정확·간결하게 한국어로 답한다."
+
+
+def ensure_csv(csv_path: Path) -> None:
+    """Create a dummy CSV with three rows if it does not exist."""
+    if csv_path.exists():
+        return
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    rows: List[dict] = [
+        {
+            "Question": "학칙 제1조는 무엇인가?",
+            "Answer": "학칙 제1조는 대학의 목적을 규정한다.",
+        },
+        {"Question": "수강신청 학점 상한은?", "Answer": "학기당 최대 18학점이다."},
+        {"Question": "졸업 요건은?", "Answer": "전공과 교양 학점을 충족해야 한다."},
+    ]
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["Question", "Answer"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def csv_to_jsonl(csv_path: Path, jsonl_path: Path) -> None:
+    """Convert the Q/A CSV file into chat-style JSONL."""
+    with open(csv_path, newline="", encoding="utf-8") as cf, open(
+        jsonl_path, "w", encoding="utf-8"
+    ) as jf:
+        reader = csv.DictReader(cf)
+        for row in reader:
+            record = {
+                "messages": [
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": row["Question"]},
+                    {"role": "assistant", "content": row["Answer"]},
+                ]
+            }
+            jf.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fine-tune Ko-Llama on CBNU ACR")
+    parser.add_argument("--data_dir", default="data", help="Directory containing CSV")
+    parser.add_argument(
+        "--max_seq_length", type=int, default=512, help="Maximum sequence length"
+    )
+    parser.add_argument("--lora_r", type=int, default=16, help="LoRA rank")
+    parser.add_argument("--lora_alpha", type=int, default=32, help="LoRA alpha")
+    parser.add_argument("--lora_dropout", type=float, default=0.05, help="LoRA dropout")
+    parser.add_argument("--num_epochs", type=int, default=3, help="Number of epochs")
+    parser.add_argument("--batch_size", type=int, default=1, help="Batch size")
+    parser.add_argument(
+        "--learning_rate", type=float, default=2e-4, help="Optimizer learning rate"
+    )
+    parser.add_argument(
+        "--adapter_file",
+        default="adapters.safetensors",
+        help="Output path for adapter weights",
+    )
+    args = parser.parse_args()
+
+    base_model = os.getenv("BASE_MODEL", "beomi/Llama-3-Open-Ko-8B")
+    data_dir = Path(args.data_dir)
+    csv_path = data_dir / "chungbuk_univ_academic_rules_QA.csv"
+    jsonl_path = data_dir / "train.jsonl"
+
+    ensure_csv(csv_path)
+    csv_to_jsonl(csv_path, jsonl_path)
+
+    model, tokenizer = load(base_model)
+
+    # Convert all linear layers to LoRA layers
+    linear_to_lora_layers(
+        model,
+        num_layers=len(model.layers),
+        config={
+            "rank": args.lora_r,
+            "scale": args.lora_alpha,
+            "dropout": args.lora_dropout,
+        },
+    )
+
+    training_args = TrainingArgs(
+        batch_size=args.batch_size,
+        iters=args.num_epochs
+        * len(open(jsonl_path, "r", encoding="utf-8").readlines()),
+        max_seq_length=args.max_seq_length,
+        adapter_file=args.adapter_file,
+    )
+
+    optimizer = opt.AdamW(learning_rate=args.learning_rate)
+
+    import types
+    from mlx_lm.tuner.datasets import load_local_dataset
+
+    config = types.SimpleNamespace(chat_feature="messages")
+    train_ds, val_ds, _ = load_local_dataset(data_dir, tokenizer, config)
+
+    if not val_ds:
+        val_ds = train_ds
+
+    train(model, optimizer, train_ds, val_ds, training_args)
+
+    # Sample inference
+    sample_question = "충북대학교의 졸업 요건은?"
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": sample_question},
+    ]
+    prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+    answer = generate(model, tokenizer, prompt, max_tokens=128)
+    print("Sample answer:", answer)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add MLX-based LoRA fine-tuning script for CBNU academic rules QA
- provide interactive inference applying LoRA adapters
- document macOS setup, training, and inference steps
- include lint workflow and requirements

## Testing
- `python -m py_compile train_acr.py infer.py`
- `python -m pip install -r requirements.txt`
- `black --check train_acr.py infer.py`
- `ruff check train_acr.py infer.py`
- `python train_acr.py --help` *(fails: ImportError: libmlx.so missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3b49d13883239f5476d83322b19c